### PR TITLE
Mobile sidebar fix

### DIFF
--- a/frontend/src/pages/Dashboard/Patient/PatientDashboard.tsx
+++ b/frontend/src/pages/Dashboard/Patient/PatientDashboard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
+import { Menu } from 'lucide-react'
 import { supabase } from '../../../lib/supabase'
 import { useClinicContext } from '../../../context/ClinicContext'
 import { usePatientQueue } from '../../../features/queue/usePatientQueue'
@@ -186,6 +187,7 @@ export default function PatientDashboard() {
     (location.state as { clinicId?: string } | null)?.clinicId ?? null
 
   const [profileOpen, setProfileOpen] = useState(false)
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
   const [loadingDashboard, setLoadingDashboard] = useState(true)
 
   const [info, setInfo] = useState<PatientInfo | null>(null)
@@ -415,11 +417,23 @@ export default function PatientDashboard() {
       }
     
     >
-      <PatientSidebar />
+      <PatientSidebar 
+        mobileOpen={mobileSidebarOpen}
+        onMobileClose={() => setMobileSidebarOpen(false)}
+      />
 
       <div className="pd-right">
         <header className="pd-header">
           <div className="pd-header-left">
+            <button
+              type="button"
+              onClick={() => setMobileSidebarOpen(true)}
+              className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-slate-300 bg-indigo-400/70 text-slate-700 shadow-sm transition hover:bg-slate-100 md:hidden"
+              aria-label="Open menu"
+            >
+              <Menu className="h-5 w-5" />
+            </button>
+
             <h1 className="pd-header-title">Patient Dashboard</h1>
             <span className="pd-header-patient">{displayName}</span>
           </div>

--- a/frontend/src/pages/Dashboard/Patient/components/PatientSidebar.tsx
+++ b/frontend/src/pages/Dashboard/Patient/components/PatientSidebar.tsx
@@ -10,6 +10,7 @@ import {
   LogOut,
   FlaskConical,
   NotebookPen,
+  X,
 } from "lucide-react"
 import {
   Sidebar,
@@ -21,13 +22,18 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarTrigger
+  SidebarTrigger,
 } from "@/components/ui/sidebar"
 
 type SidebarItem = {
   title: string
   url: string
   icon: React.ComponentType<{ className?: string }>
+}
+
+type PatientSidebarProps = {
+  mobileOpen?: boolean
+  onMobileClose?: () => void
 }
 
 const mainItems: SidebarItem[] = [
@@ -78,8 +84,10 @@ const healthItems: SidebarItem[] = [
 
 function SidebarLink({
   item,
+  onNavigate,
 }: {
   item: SidebarItem
+  onNavigate?: () => void
 }) {
   const Icon = item.icon
 
@@ -89,14 +97,15 @@ function SidebarLink({
         <NavLink
           to={item.url}
           end={item.url === "/dashboard/patient"}
+          onClick={onNavigate}
           className={({ isActive }) =>
             [
-              "flex items-center gap-3 px-3 py-5 text-[16px] bg-white border border-slate-300 font-medium transition-colors rounded-lg",
+              "flex items-center gap-3 rounded-lg border border-slate-300 bg-white px-3 py-5 text-[16px] font-medium transition-colors",
               isActive
                 ? "bg-white text-indigo-900 shadow-sm"
                 : "text-slate-700 hover:bg-indigo-200 hover:text-indigo-700",
             ].join(" ")
-      }
+          }
         >
           <Icon className="h-5 w-5 shrink-0" />
           <span>{item.title}</span>
@@ -106,105 +115,193 @@ function SidebarLink({
   )
 }
 
-export default function PatientSidebar() {
+export default function PatientSidebar({
+  mobileOpen = false,
+  onMobileClose,
+}: PatientSidebarProps) {
   const { profile, logout } = useAuth()
   const displayName = profile?.full_name?.trim() || "Patient"
 
   return (
-    <Sidebar
-      collapsible="icon"
-      className="top-[115px] h-[calc(100vh-120px)] bg-white rounded-2xl"
-    >
-      <SidebarHeader className="border bg-white rounded-xl border-slate-300 px-3 py-4">
-        <div className="flex items-start justify-between gap-3 group-data-[collapsible=icon]:justify-center">
-          <div className="flex min-w-0 items-center gap-3 group-data-[collapsible=icon]:hidden">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-white shadow-sm">
+    <>
+      <div
+        className={[
+          "fixed inset-0 z-50 bg-white transition-transform duration-300 ease-in-out md:hidden",
+          mobileOpen ? "translate-x-0" : "-translate-x-full pointer-events-none",
+        ].join(" ")}
+        aria-hidden={!mobileOpen}
+      >
+        <div className="flex h-full flex-col">
+          <div className="flex items-center justify-between border-b border-slate-200 bg-slate-50/60 px-6 py-6">
+            <div className="flex min-w-0 items-center gap-4">
+              <div className="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-full border-2 border-white bg-white shadow-md">
+                <img
+                  src="/assets/default_profile_picture.png"
+                  alt="Profile Picture"
+                  className="h-full w-full object-cover"
+                />
+              </div>
+
+              <div className="min-w-0">
+                <h2 className="truncate text-lg font-bold leading-tight text-slate-900">
+                  {displayName}
+                </h2>
+                <p className="truncate text-sm font-medium text-slate-500">
+                  Patient Portal
+                </p>
+              </div>
+            </div>
+
+            <button
+              type="button"
+              onClick={onMobileClose}
+              className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-500 shadow-sm transition hover:bg-slate-100"
+              aria-label="Close menu"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+
+          <div className="flex-1 overflow-y-auto px-4 py-6">
+            <SidebarGroup>
+              <SidebarGroupLabel className="px-4 text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">
+                Main
+              </SidebarGroupLabel>
+
+              <SidebarMenu className="space-y-1">
+                {mainItems.map((item) => (
+                  <SidebarLink
+                    key={item.title}
+                    item={item}
+                    onNavigate={onMobileClose}
+                  />
+                ))}
+              </SidebarMenu>
+            </SidebarGroup>
+
+            <SidebarGroup className="mt-8">
+              <SidebarGroupLabel className="px-4 text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">
+                Health
+              </SidebarGroupLabel>
+
+              <SidebarMenu className="space-y-1">
+                {healthItems.map((item) => (
+                  <SidebarLink
+                    key={item.title}
+                    item={item}
+                    onNavigate={onMobileClose}
+                  />
+                ))}
+              </SidebarMenu>
+            </SidebarGroup>
+          </div>
+
+          <div className="border-t border-slate-100 bg-slate-50/60 p-6">
+            <button
+              type="button"
+              onClick={() => void logout()}
+              className="inline-flex w-full items-center justify-center gap-3 rounded-2xl bg-indigo-500 py-4 text-sm font-semibold text-white transition hover:bg-indigo-600"
+            >
+              <LogOut className="h-5 w-5" />
+              Log Out
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <Sidebar
+        collapsible="icon"
+        className="hidden bg-white md:flex md:top-[115px] md:h-[calc(100vh-120px)] md:rounded-2xl"
+      >
+        <SidebarHeader className="rounded-xl border border-slate-300 bg-white px-3 py-4">
+          <div className="flex items-start justify-between gap-3 group-data-[collapsible=icon]:justify-center">
+            <div className="flex min-w-0 items-center gap-3 group-data-[collapsible=icon]:hidden">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-white shadow-sm">
+                <img
+                  src="/assets/default_profile_picture.png"
+                  alt="Profile Picture"
+                  className="h-12 w-10 rounded-full object-cover"
+                />
+              </div>
+
+              <div className="min-w-0">
+                <p className="truncate text-sm font-semibold text-slate-900">
+                  {displayName}
+                </p>
+
+                <p className="truncate text-xs font-semibold text-slate-600">
+                  Patient Portal
+                </p>
+              </div>
+            </div>
+
+            <div className="hidden items-center justify-center group-data-[collapsible=icon]:w-full md:flex">
+              <SidebarTrigger className="h-9 w-9 shrink-0 rounded-md border border-slate-300 bg-white text-slate-700 shadow-sm hover:bg-slate-100" />
+            </div>
+          </div>
+
+          <div className="hidden group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-white shadow-sm">
               <img
-              src="/assets/default_profile_picture.png"
-              alt="Profile Picture"
-              className="h-12 w-10 rounded-full object-cover"
-            />
+                src="/assets/default_profile_picture.png"
+                alt="Profile Picture"
+                className="h-10 w-8 rounded-full object-cover"
+              />
+            </div>
+          </div>
+        </SidebarHeader>
+
+        <SidebarContent>
+          <SidebarGroup>
+            <SidebarGroupLabel className="text-[11px] font-bold uppercase tracking-wide text-slate-600">
+              Main
+            </SidebarGroupLabel>
+
+            <SidebarMenu>
+              {mainItems.map((item) => (
+                <SidebarLink key={item.title} item={item} />
+              ))}
+            </SidebarMenu>
+          </SidebarGroup>
+
+          <SidebarGroup>
+            <SidebarGroupLabel className="text-[11px] font-bold uppercase tracking-wide text-slate-600">
+              Health
+            </SidebarGroupLabel>
+
+            <SidebarMenu>
+              {healthItems.map((item) => (
+                <SidebarLink key={item.title} item={item} />
+              ))}
+            </SidebarMenu>
+          </SidebarGroup>
+        </SidebarContent>
+
+        <SidebarFooter className="rounded-xl border border-slate-300/70 p-3 pb-4">
+          <div className="rounded-xl bg-white p-3 group-data-[collapsible=icon]:hidden">
+            <button
+              type="button"
+              onClick={() => void logout()}
+              className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-indigo-500 py-2 text-sm font-medium text-white transition hover:bg-indigo-600"
+            >
+              <LogOut className="h-4 w-4" />
+              Log Out
+            </button>
           </div>
 
-          <div className="min-w-0">
-            <p className="truncate text-sm font-semibold text-slate-900">
-            {displayName}
-            </p>
-
-            <p className="truncate text-xs font-semibold text-slate-600">
-              Patient Portal
-            </p>
+          <div className="hidden group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center">
+            <button
+              type="button"
+              onClick={() => void logout()}
+              className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-500 text-white transition hover:bg-indigo-600"
+              aria-label="Log out"
+              title="Log out"
+            >
+              <LogOut className="h-4 w-8" />
+            </button>
           </div>
-      </div>
-
-      <div className="flex items-center justify-center group-data-[collapsible=icon]:w-full">
-        <SidebarTrigger className="h-9 w-9 shrink-0 rounded-md border border-slate-300 bg-white text-slate-700 shadow-sm hover:bg-slate-100" />
-      </div>
-    </div>
-
-      <div className="hidden group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center">
-        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-white shadow-sm">
-          <img
-            src="/assets/default_profile_picture.png"
-            alt="Profile Picture"
-            className="h-10 w-8 rounded-full object-cover"
-          />
-        </div>
-      </div>
-    </SidebarHeader>
-
-      <SidebarContent className="">
-        <SidebarGroup>
-          <SidebarGroupLabel className="text-[11px] font-bold uppercase tracking-wide text-slate-600">
-            Main
-          </SidebarGroupLabel>
-
-          <SidebarMenu>
-            {mainItems.map((item) => (
-              <SidebarLink key={item.title} item={item} />
-            ))}
-          </SidebarMenu>
-        </SidebarGroup>
-
-        <SidebarGroup>
-          <SidebarGroupLabel className="text-[11px] font-bold uppercase tracking-wide text-slate-600">
-            Health
-          </SidebarGroupLabel>
-
-          <SidebarMenu>
-            {healthItems.map((item) => (
-              <SidebarLink key={item.title} item={item} />
-            ))}
-          </SidebarMenu>
-        </SidebarGroup>
-      </SidebarContent>
-
-      <SidebarFooter className="border rounded-xl border-slate-300/70 p-3 pb-4">
-        <div className="rounded-xl bg-white p-3 group-data-[collapsible=icon]:hidden">
-
-          <button
-            type="button"
-            onClick={() => void logout()}
-            className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-indigo-500  py-2 text-sm font-medium text-white transition hover:bg-indigo-600"
-          >
-            <LogOut className="h-4 w-4" />
-            Log Out
-          </button>
-        </div>
-
-        <div className="hidden group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center">
-          <button
-            type="button"
-            onClick={() => void logout()}
-            className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-500 text-white transition hover:bg-indigo-600"
-            aria-label="Log out"
-            title="Log out"
-          >
-            <LogOut className="h-4 w-8" />
-          </button>
-        </div>
-      </SidebarFooter>
-
-    </Sidebar>
+        </SidebarFooter>
+      </Sidebar>
+    </>
   )
 }

--- a/frontend/src/pages/Dashboard/Patient/components/PatientSidebar.tsx
+++ b/frontend/src/pages/Dashboard/Patient/components/PatientSidebar.tsx
@@ -155,7 +155,7 @@ export default function PatientSidebar({
             <button
               type="button"
               onClick={onMobileClose}
-              className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-500 shadow-sm transition hover:bg-slate-100"
+              className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-slate-200 bg-red-500/80 text-slate-700 shadow-sm transition hover:bg-slate-100"
               aria-label="Close menu"
             >
               <X className="h-5 w-5" />


### PR DESCRIPTION
## Summary

Implements a mobile-friendly sidebar experience for the Patient Dashboard by introducing a hamburger menu and full-screen sidebar drawer.

---

## Changes Made

* Added a mobile-only hamburger menu button to the Patient Dashboard header
* Implemented sidebar toggle state in `PatientDashboard.tsx`
* Updated `PatientSidebar.tsx` to support a full-screen mobile drawer overlay
* Preserved existing desktop sidebar behavior (no visual regressions)
* Hid search bar on mobile for better header layout

---

## Type of Change

* [ ] Bug fix
* [ ] New feature
* [x] Enhancement
* [ ] Refactor
* [ ] Documentation update

---

## Testing

* Ran frontend locally
* Verified hamburger menu appears only on mobile screen sizes
* Confirmed sidebar opens and closes correctly on mobile
* Ensured desktop sidebar behavior remains unchanged
* Tested logout and navigation links within mobile sidebar

---

## Checklist

Before submitting this PR, please confirm:

* [x] Code compiles and runs locally
* [x] No unnecessary console logs
* [ ] Relevant issue is linked
* [x] Changes were tested
* [x] PR title clearly describes the change

---

## Additional Notes

* The mobile sidebar is implemented within `PatientDashboard` instead of the global `Header` due to `SidebarProvider` scope. This ensures proper state control without restructuring the layout.
* No changes were made to migration files or backend logic.
* This is a purely frontend enhancement focused on mobile UX.
