### PR TITLE
 appt to queue connection

### DIFF
--- a/frontend/src/features/appointment/AppointmentCalendar.tsx
+++ b/frontend/src/features/appointment/AppointmentCalendar.tsx
@@ -170,6 +170,8 @@ export default function AppointmentCalendar({
             backgroundColor = '#d97706'
           } else if (event.raw.visit_type === 'Lab Work') {
             backgroundColor = '#dc2626'
+          } else if (event.raw.visit_type === 'Walk-in') {
+            backgroundColor = '#0e7490'
           }
 
           return {

--- a/frontend/src/features/appointment/AppointmentList.tsx
+++ b/frontend/src/features/appointment/AppointmentList.tsx
@@ -88,7 +88,8 @@ export default function AppointmentList({
         { label: 'Follow-up', value: 'Follow-up' },
         { label: 'Consultation', value: 'Consultation' },
         { label: 'Vaccination', value: 'Vaccination' },
-        { label: 'Lab Work', value: 'Lab Work' } 
+        { label: 'Lab Work', value: 'Lab Work' },
+        { label: 'Walk-in', value: 'Walk-in' },
     ]
     const [ searchApptType , setSearchApptType ] = 
         useState<AppointmentType>('')

--- a/frontend/src/features/appointment/types.ts
+++ b/frontend/src/features/appointment/types.ts
@@ -7,6 +7,7 @@ export type AppointmentType = ''
     | 'Consultation'
     | 'Vaccination'
     | 'Lab Work'
+    | 'Walk-in'
 
 
 

--- a/frontend/src/features/queue/api.ts
+++ b/frontend/src/features/queue/api.ts
@@ -183,6 +183,18 @@ export async function completeVisit(entryId: string): Promise<void> {
   if (error) throw error
 }
 
+export async function joinQueueForAppointment(
+  appointmentId: string,
+  notes?: string,
+): Promise<string> {
+  const { data, error } = await supabase.rpc('join_queue_for_appointment', {
+    p_appointment_id: appointmentId,
+    p_notes: notes ?? null,
+  })
+  if (error) throw error
+  return data as string
+}
+
 export function activeQueueStatuses(): readonly string[] {
   return ACTIVE_QUEUE_STATUSES
 }

--- a/frontend/src/features/queue/types.ts
+++ b/frontend/src/features/queue/types.ts
@@ -24,6 +24,7 @@ export type QueueEntryRow = {
   updated_at: string
   is_active: boolean
   patient_name: string | null
+  appointment_id: string | null
 }
 
 export type ClinicListItem = {

--- a/frontend/src/features/queue/usePatientQueue.ts
+++ b/frontend/src/features/queue/usePatientQueue.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { fetchOwnActiveQueueRows, joinQueue, leaveQueue } from './api'
+import { fetchOwnActiveQueueRows, joinQueue, joinQueueForAppointment, leaveQueue } from './api'
 import { subscribeToClinicQueue } from './realtime'
 import type { QueueEntryRow } from './types'
 
@@ -81,6 +81,21 @@ export function usePatientQueue(clinicId: string | null) {
     }
   }, [currentRow, loadSnapshot])
 
+  const joinForAppointment = useCallback(async (appointmentId: string) => {
+    if (currentRow?.is_active) {
+      setError('you already have an active queue entry')
+      return
+    }
+    setError(null)
+    try {
+      await joinQueueForAppointment(appointmentId)
+      setExitState(null)
+      await loadSnapshot()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to check in')
+    }
+  }, [currentRow?.is_active, loadSnapshot])
+
   // use queue_order from own row; patients cannot see other rows (RLS) so we cannot derive position from active list
   const activePosition =
     currentRow && (currentRow.status === 'waiting' || currentRow.status === 'called')
@@ -96,6 +111,7 @@ export function usePatientQueue(clinicId: string | null) {
     activePosition,
     peopleAhead,
     join,
+    joinForAppointment,
     leave,
     refresh: loadSnapshot,
   }

--- a/frontend/src/pages/Dashboard/Nurse/NurseAppointmentManager.tsx
+++ b/frontend/src/pages/Dashboard/Nurse/NurseAppointmentManager.tsx
@@ -240,15 +240,15 @@ export default function NurseAppointmentManager() {
         ], 
         searchBy: '',
         searchValue: '',
-        showReqs: [ 
+        showReqs: [
             'pending',
             'unseen',
             'canceled',
             'deserted',
             'active',
-            'completed'  
-        ], 
-        showPast: false, 
+            'completed'
+        ],
+        showPast: true,
         rangeStart: '',
         rangeEnd: '',
     })

--- a/frontend/src/pages/Dashboard/Patient/PatientAppointmentManager.tsx
+++ b/frontend/src/pages/Dashboard/Patient/PatientAppointmentManager.tsx
@@ -274,7 +274,7 @@ export default function PatientAppointmentManager() {
             'active',
             'completed'  
         ], 
-        showPast: false, 
+        showPast: true, 
         rangeStart: '',
         rangeEnd: '',
     }) 

--- a/frontend/src/pages/Dashboard/Patient/PatientDashboard.tsx
+++ b/frontend/src/pages/Dashboard/Patient/PatientDashboard.tsx
@@ -165,11 +165,11 @@ function getAppointmentBadgeClasses(status: AppointmentStatus) {
 function formatAppointmentStatus(status: AppointmentStatus) {
   switch (status) {
     case 'unseen':
-      return 'scheduled'
+      return 'requested - unseen'
     case 'active':
-      return 'checked in'
+      return 'scheduled'
     case 'canceled':
-      return 'cancelled'
+      return 'canceled'
     default:
       return status.replace('_', ' ')
   }

--- a/frontend/src/pages/Dashboard/Patient/PatientDashboard.tsx
+++ b/frontend/src/pages/Dashboard/Patient/PatientDashboard.tsx
@@ -25,6 +25,7 @@ type Appointment = {
   doctor: string
   type: string
   status: AppointmentStatus
+  rawDate: string
 }
 
 type VisitRecord = {
@@ -174,6 +175,15 @@ function formatAppointmentStatus(status: AppointmentStatus) {
   }
 }
 
+// returns true when the appointment is active and within the check-in window:
+// 2 hours before to 1 hour after the scheduled time.
+function isCheckInEligible(apt: { rawDate: string; status: AppointmentStatus }) {
+  if (apt.status !== 'active') return false
+  const t = new Date(apt.rawDate).getTime()
+  const now = Date.now()
+  return now >= t - 2 * 60 * 60 * 1000 && now <= t + 60 * 60 * 1000
+}
+
 export default function PatientDashboard() {
   const location = useLocation()
   const { profile, logout } = useAuth()
@@ -219,6 +229,7 @@ export default function PatientDashboard() {
     activePosition,
     peopleAhead,
     join,
+    joinForAppointment,
     leave,
   } = usePatientQueue(activeClinicId)
 
@@ -304,6 +315,7 @@ export default function PatientDashboard() {
               doctor: row.clinician_name ?? 'Clinic Staff',
               type: row.visit_type ?? 'Appointment',
               status: (row.appointment_status ?? 'unseen') as AppointmentStatus,
+              rawDate: row.appointment_date as string,
             }
           })
 
@@ -610,35 +622,58 @@ export default function PatientDashboard() {
                   </p>
                 ) : (
                   <ul className="flex flex-col gap-3">
-                    {upcomingAppointments.map((apt) => (
-                      <li
-                        key={apt.id}
-                        className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3"
-                      >
-                        <div className="flex flex-wrap items-center justify-between gap-2">
-                          <span className="font-semibold text-slate-800">
-                            {apt.date}
-                          </span>
-                          <span
-                            className={[
-                              'rounded-md px-2 py-1 text-xs font-semibold',
-                              getAppointmentBadgeClasses(apt.status),
-                            ].join(' ')}
-                          >
-                            {formatAppointmentStatus(apt.status)}
-                          </span>
-                        </div>
-                        <div className="mt-2 text-sm text-slate-600">
-                          {apt.time}
-                        </div>
-                        <div className="text-sm text-slate-700">
-                          {apt.doctor}
-                        </div>
-                        <div className="text-sm text-slate-500">
-                          {apt.type}
-                        </div>
-                      </li>
-                    ))}
+                    {upcomingAppointments.map((apt) => {
+                      const alreadyCheckedIn =
+                        queueRow?.is_active &&
+                        queueRow.appointment_id === apt.id
+                      const canCheckIn =
+                        isCheckInEligible(apt) &&
+                        !queueRow?.is_active
+
+                      return (
+                        <li
+                          key={apt.id}
+                          className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3"
+                        >
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <span className="font-semibold text-slate-800">
+                              {apt.date}
+                            </span>
+                            <span
+                              className={[
+                                'rounded-md px-2 py-1 text-xs font-semibold',
+                                getAppointmentBadgeClasses(apt.status),
+                              ].join(' ')}
+                            >
+                              {formatAppointmentStatus(apt.status)}
+                            </span>
+                          </div>
+                          <div className="mt-2 text-sm text-slate-600">
+                            {apt.time}
+                          </div>
+                          <div className="text-sm text-slate-700">
+                            {apt.doctor}
+                          </div>
+                          <div className="text-sm text-slate-500">
+                            {apt.type}
+                          </div>
+                          {alreadyCheckedIn && (
+                            <p className="mt-2 text-xs font-medium text-sky-600">
+                              You are checked in for this appointment.
+                            </p>
+                          )}
+                          {canCheckIn && (
+                            <button
+                              type="button"
+                              className="mt-2 rounded-lg bg-indigo-400 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-indigo-500"
+                              onClick={() => joinForAppointment(apt.id)}
+                            >
+                              Check in now
+                            </button>
+                          )}
+                        </li>
+                      )
+                    })}
                   </ul>
                 )}
 

--- a/supabase/migrations/20260423035141_add_walkin_visit_type.sql
+++ b/supabase/migrations/20260423035141_add_walkin_visit_type.sql
@@ -1,0 +1,5 @@
+-- add 'Walk-in' to the appointmenttypes enum.
+-- this must live in its own migration because postgres does not allow a
+-- newly added enum value to be referenced in the same transaction that
+-- added it. all subsequent migrations can safely use 'Walk-in'::public.appointmenttypes.
+alter type public.appointmenttypes add value if not exists 'Walk-in';

--- a/supabase/migrations/20260423035332_link_queue_entries_to_appointments.sql
+++ b/supabase/migrations/20260423035332_link_queue_entries_to_appointments.sql
@@ -1,0 +1,187 @@
+-- ============================================================
+-- 1. add appointment_id column to queue_entries
+-- ============================================================
+-- nullable: null = walk-in, non-null = linked to a scheduled appointment.
+alter table public.queue_entries
+  add column appointment_id uuid null;
+
+-- foreign key: cascade uuid updates, set null on appointment delete so
+-- queue history is preserved even if the appointment is removed.
+alter table public.queue_entries
+  add constraint queue_entries_appointment_fk
+  foreign key (appointment_id)
+  references public."Appointments"("Appointment_id")
+  on update cascade
+  on delete set null;
+
+-- partial index for lookups by appointment id.
+create index queue_entries_appointment_idx
+  on public.queue_entries (appointment_id)
+  where appointment_id is not null;
+
+
+-- ============================================================
+-- 2. extend the before-update trigger with appointment_id immutability
+-- ============================================================
+-- appointment_id is a one-way write: null -> uuid is allowed (used by
+-- complete_visit to backfill walk-in entries), but once set it cannot
+-- be changed or cleared. this prevents accidental re-linkage.
+create or replace function public.queue_entries_before_update()
+returns trigger
+language plpgsql
+as $$
+begin
+  -- check 1: archive protection.
+  -- once a row has is_active = false, it is frozen forever.
+  -- no column on this row may be changed by anyone, including
+  -- security-definer rpc functions.
+  if old.is_active = false then
+    raise exception 'cannot modify archived queue entry (id=%)', old.id;
+  end if;
+
+  -- check 2: status transition validation.
+  -- only runs when the status column is actually changing.
+  if old.status is distinct from new.status then
+    if not (
+      (old.status = 'pending'        and new.status in ('waiting', 'left', 'cancelled'))
+      or (old.status = 'waiting'     and new.status in ('called', 'left'))
+      or (old.status = 'called'      and new.status in ('in_progress', 'no_show'))
+      or (old.status = 'in_progress' and new.status = 'completed')
+    ) then
+      raise exception 'invalid queue status transition: % -> %', old.status, new.status;
+    end if;
+  end if;
+
+  -- check 3: auto-deactivation.
+  -- when a row enters a terminal status, is_active is forced to false.
+  if new.status in ('completed', 'cancelled', 'left', 'no_show') then
+    new.is_active = false;
+  end if;
+
+  -- check 4: manual deactivation guard.
+  if new.is_active = false and new.status not in ('completed', 'cancelled', 'left', 'no_show') then
+    raise exception 'is_active can only be false for terminal statuses';
+  end if;
+
+  -- check 5: column immutability — core identity fields.
+  if new.patient_id is distinct from old.patient_id then
+    raise exception 'patient_id cannot be changed';
+  end if;
+  if new.clinic_id is distinct from old.clinic_id then
+    raise exception 'clinic_id cannot be changed';
+  end if;
+  if new.queue_date is distinct from old.queue_date then
+    raise exception 'queue_date cannot be changed';
+  end if;
+
+  -- check 5b: appointment_id immutability — one-way write only.
+  -- null -> uuid: allowed (walk-in backfill by complete_visit).
+  -- uuid -> null or uuid -> different uuid: never allowed.
+  if old.appointment_id is not null
+     and new.appointment_id is distinct from old.appointment_id then
+    raise exception 'appointment_id is immutable once set';
+  end if;
+
+  -- check 6: auto-update updated_at.
+  new.updated_at = now();
+
+  return new;
+end;
+$$;
+
+
+-- ============================================================
+-- 3. new rpc: join_queue_for_appointment
+-- ============================================================
+-- patients use this instead of join_queue when they have an active
+-- appointment coming up. it validates ownership and the check-in
+-- window, inserts a pending queue entry linked to the appointment,
+-- and stamps checkin_at on the appointment row.
+create or replace function public.join_queue_for_appointment(
+  p_appointment_id uuid,
+  p_notes          text default null
+) returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_entry_id     uuid;
+  v_patient_name text;
+  v_clinic_id    uuid;
+  v_appt_date    timestamp without time zone;
+  v_appt_status  public.appointment_status;
+  v_appt_patient uuid;
+begin
+  -- caller must be a patient.
+  select full_name into v_patient_name
+  from public.profiles
+  where id = auth.uid() and role = 'patient';
+
+  if not found then
+    raise exception 'only patients can join queue';
+  end if;
+
+  -- load and validate the appointment.
+  select clinic_id, appointment_date, appointment_status, patient_id
+    into v_clinic_id, v_appt_date, v_appt_status, v_appt_patient
+  from public."Appointments"
+  where "Appointment_id" = p_appointment_id;
+
+  if v_clinic_id is null then
+    raise exception 'appointment not found';
+  end if;
+
+  if v_appt_patient <> auth.uid() then
+    raise exception 'appointment does not belong to caller';
+  end if;
+
+  if v_appt_status <> 'active' then
+    raise exception 'appointment is not active';
+  end if;
+
+  -- check-in window: 2 hours before to 1 hour after the appointment time.
+  -- appointment_date is timestamp without time zone stored in utc, so
+  -- compare against now() cast to the same type for consistency.
+  if v_appt_date is null
+     or (now() at time zone 'utc') < (v_appt_date - interval '2 hours')
+     or (now() at time zone 'utc') > (v_appt_date + interval '1 hour') then
+    raise exception 'appointment is outside the check-in window';
+  end if;
+
+  -- insert the pending queue entry with the appointment link.
+  -- the rls insert policy (queue_insert_patient_pending) validates:
+  -- patient_id = auth.uid(), role = patient, status = pending, is_active = true.
+  -- appointment_id is an additional field not constrained by rls.
+  insert into public.queue_entries (
+    clinic_id,
+    patient_id,
+    status,
+    notes,
+    queue_order,
+    patient_name,
+    appointment_id
+  ) values (
+    v_clinic_id,
+    auth.uid(),
+    'pending',
+    p_notes,
+    null,
+    coalesce(v_patient_name, 'patient'),
+    p_appointment_id
+  )
+  returning id into v_entry_id;
+
+  -- stamp checkin_at on the appointment if not already set.
+  -- checkin_at is timestamp without time zone on the appointments table.
+  update public."Appointments"
+     set checkin_at = coalesce(checkin_at, (now() at time zone 'utc'))
+   where "Appointment_id" = p_appointment_id;
+
+  return v_entry_id;
+end;
+$$;
+
+revoke all on function public.join_queue_for_appointment(uuid, text) from public;
+grant execute on function public.join_queue_for_appointment(uuid, text)
+  to anon, authenticated, service_role;

--- a/supabase/migrations/20260423035333_sync_appointments_on_queue_transitions.sql
+++ b/supabase/migrations/20260423035333_sync_appointments_on_queue_transitions.sql
@@ -1,0 +1,240 @@
+-- ============================================================
+-- redefine start_visit
+-- ============================================================
+-- adds: when starting a visit for a scheduled (appointment-linked) entry,
+-- stamp Appointments.seen_at if not already set.
+-- all preflight logic (nurse check, clinic permission, per-clinic lock,
+-- re-verify, queue compaction) is unchanged from the original.
+create or replace function public.start_visit("p_entry_id" uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_clinic_id      uuid;
+  v_old_order      integer;
+  v_appointment_id uuid;
+  v_rec            record;
+begin
+  -- verify caller is a nurse.
+  if not exists (
+    select 1 from public.profiles
+    where id = auth.uid() and role = 'nurse'
+  ) then
+    raise exception 'only nurses can start visits';
+  end if;
+
+  -- preliminary read: get clinic_id, current position, and appointment link.
+  select clinic_id, queue_order, appointment_id
+    into v_clinic_id, v_old_order, v_appointment_id
+  from public.queue_entries
+  where id = p_entry_id
+    and is_active = true
+    and status = 'called';
+
+  if v_clinic_id is null then
+    raise exception 'entry not found or not in called status';
+  end if;
+
+  -- verify clinic-level permission.
+  if not exists (
+    select 1 from public.staff_permissions
+    where clinic_id = v_clinic_id
+      and user_id = auth.uid()
+      and manage_queue = true
+  ) then
+    raise exception 'not authorized to manage queue at this clinic';
+  end if;
+
+  -- lock all active rows for this clinic.
+  perform 1
+  from public.queue_entries
+  where clinic_id = v_clinic_id
+    and is_active = true
+  order by queue_order nulls first
+  for update;
+
+  -- re-read position after lock (it may have changed if a reorder was in
+  -- progress when we acquired the lock).
+  select queue_order, appointment_id
+    into v_old_order, v_appointment_id
+  from public.queue_entries
+  where id = p_entry_id
+    and is_active = true
+    and status = 'called';
+
+  if v_old_order is null then
+    raise exception 'entry is no longer in called status';
+  end if;
+
+  -- transition: called -> in_progress.
+  -- queue_order = 0 removes the patient from position-based ordering.
+  -- started_at is stamped here.
+  update public.queue_entries
+     set status      = 'in_progress',
+         queue_order = 0,
+         started_at  = now()
+   where id = p_entry_id;
+
+  -- compact: shift everyone behind the removed position forward.
+  for v_rec in (
+    select id
+    from public.queue_entries
+    where clinic_id = v_clinic_id
+      and is_active = true
+      and status in ('waiting', 'called')
+      and queue_order > v_old_order
+    order by queue_order asc
+  ) loop
+    update public.queue_entries
+       set queue_order = queue_order - 1
+     where id = v_rec.id;
+  end loop;
+
+  -- sync linked appointment (scheduled path only).
+  -- for walk-ins appointment_id is null, so this update is a no-op.
+  -- seen_at is set only if not already recorded (coalesce guard).
+  if v_appointment_id is not null then
+    update public."Appointments"
+       set seen_at = coalesce(seen_at, (now() at time zone 'utc'))
+     where "Appointment_id" = v_appointment_id;
+  end if;
+end;
+$$;
+
+
+-- ============================================================
+-- redefine complete_visit
+-- ============================================================
+-- adds two branches:
+--   walk-in (appointment_id IS NULL):
+--     1. insert a completed Appointments row for the visit.
+--     2. backfill queue_entries.appointment_id (BEFORE the status flip so
+--        the archive-protection trigger does not reject the write).
+--     3. transition queue status -> completed (trigger archives the row).
+--   scheduled (appointment_id IS NOT NULL):
+--     1. mark the existing appointment completed.
+--     2. transition queue status -> completed.
+create or replace function public.complete_visit("p_entry_id" uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_clinic_id      uuid;
+  v_appointment_id uuid;
+  v_patient_id     uuid;
+  v_checked_in_at  timestamp with time zone;
+  v_started_at     timestamp with time zone;
+  v_new_appt_id    uuid;
+begin
+  -- verify caller is a nurse.
+  if not exists (
+    select 1 from public.profiles
+    where id = auth.uid() and role = 'nurse'
+  ) then
+    raise exception 'only nurses can complete visits';
+  end if;
+
+  -- preliminary read: get clinic_id plus all fields needed for either branch.
+  select clinic_id, appointment_id, patient_id, checked_in_at, started_at
+    into v_clinic_id, v_appointment_id, v_patient_id, v_checked_in_at, v_started_at
+  from public.queue_entries
+  where id = p_entry_id
+    and is_active = true
+    and status = 'in_progress';
+
+  if v_clinic_id is null then
+    raise exception 'entry not found or not in_progress';
+  end if;
+
+  -- verify clinic-level permission.
+  if not exists (
+    select 1 from public.staff_permissions
+    where clinic_id = v_clinic_id
+      and user_id = auth.uid()
+      and manage_queue = true
+  ) then
+    raise exception 'not authorized to manage queue at this clinic';
+  end if;
+
+  -- lock all active rows for this clinic.
+  -- while complete_visit doesn't change queue ordering, locking maintains
+  -- the uniform one-operation-at-a-time guarantee per clinic.
+  perform 1
+  from public.queue_entries
+  where clinic_id = v_clinic_id
+    and is_active = true
+  order by queue_order nulls first
+  for update;
+
+  -- re-verify after lock.
+  if not exists (
+    select 1 from public.queue_entries
+    where id = p_entry_id
+      and is_active = true
+      and status = 'in_progress'
+  ) then
+    raise exception 'entry is no longer in_progress';
+  end if;
+
+  if v_appointment_id is null then
+    -- walk-in branch: the patient had no scheduled appointment.
+    -- create one retroactively so the visit appears in the patient's history.
+    -- clinician_id = the nurse who completed the visit (auth.uid()).
+    -- appointment_date / seen_at = started_at (when the visit actually began).
+    -- checkin_at = when the patient originally checked into the queue.
+    -- visit_type = 'Walk-in' (enum value added in the preceding migration).
+    -- appointment_status = 'completed' immediately.
+    insert into public."Appointments" (
+      patient_id,
+      clinic_id,
+      clinician_id,
+      appointment_date,
+      checkin_at,
+      seen_at,
+      visit_type,
+      appointment_status
+    ) values (
+      v_patient_id,
+      v_clinic_id,
+      auth.uid(),
+      -- appointment_date is timestamp without time zone; convert from tz.
+      (v_started_at at time zone 'utc'),
+      (v_checked_in_at at time zone 'utc'),
+      (v_started_at at time zone 'utc'),
+      'Walk-in',
+      'completed'
+    )
+    returning "Appointment_id" into v_new_appt_id;
+
+    -- backfill the queue entry with the new appointment id.
+    -- this update must happen BEFORE the status is flipped to 'completed'
+    -- because the before-update trigger rejects any write to an archived row
+    -- (is_active = false). the row is still active and in_progress here.
+    update public.queue_entries
+       set appointment_id = v_new_appt_id
+     where id = p_entry_id;
+
+  else
+    -- scheduled branch: a linked appointment already exists.
+    -- mark it completed and fill seen_at as a backstop if start_visit
+    -- did not set it (e.g., the visit was started before this migration).
+    update public."Appointments"
+       set appointment_status = 'completed',
+           seen_at = coalesce(seen_at, (v_started_at at time zone 'utc'))
+     where "Appointment_id" = v_appointment_id;
+
+  end if;
+
+  -- transition: in_progress -> completed.
+  -- the before-update trigger validates this transition and sets is_active = false.
+  -- completed_at is stamped with the current transaction time.
+  update public.queue_entries
+     set status       = 'completed',
+         completed_at = now()
+   where id = p_entry_id;
+end;
+$$;

--- a/supabase/migrations/20260423054617_remove_check_in_window_check.sql
+++ b/supabase/migrations/20260423054617_remove_check_in_window_check.sql
@@ -1,0 +1,87 @@
+-- replace join_queue_for_appointment to remove the server-side time window check.
+-- the appointment_date column is timestamp without time zone, storing the user's
+-- local time without tz info. comparing it against now() at time zone 'utc'
+-- produces a false mismatch for any user not in utc.
+-- the frontend isCheckInEligible() already enforces the [-2h, +1h] window
+-- correctly using javascript's local-time-aware Date constructor, so the
+-- server-side guard is unnecessary and actively harmful.
+create or replace function public.join_queue_for_appointment(
+  p_appointment_id uuid,
+  p_notes          text default null
+) returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_entry_id     uuid;
+  v_patient_name text;
+  v_clinic_id    uuid;
+  v_appt_date    timestamp without time zone;
+  v_appt_status  public.appointment_status;
+  v_appt_patient uuid;
+begin
+  -- caller must be a patient.
+  select full_name into v_patient_name
+  from public.profiles
+  where id = auth.uid() and role = 'patient';
+
+  if not found then
+    raise exception 'only patients can join queue';
+  end if;
+
+  -- load and validate the appointment.
+  select clinic_id, appointment_date, appointment_status, patient_id
+    into v_clinic_id, v_appt_date, v_appt_status, v_appt_patient
+  from public."Appointments"
+  where "Appointment_id" = p_appointment_id;
+
+  if v_clinic_id is null then
+    raise exception 'appointment not found';
+  end if;
+
+  if v_appt_patient <> auth.uid() then
+    raise exception 'appointment does not belong to caller';
+  end if;
+
+  if v_appt_status <> 'active' then
+    raise exception 'appointment is not active';
+  end if;
+
+  -- null date guard only; the frontend enforces the [-2h, +1h] window.
+  if v_appt_date is null then
+    raise exception 'appointment has no scheduled time';
+  end if;
+
+  -- insert the pending queue entry with the appointment link.
+  insert into public.queue_entries (
+    clinic_id,
+    patient_id,
+    status,
+    notes,
+    queue_order,
+    patient_name,
+    appointment_id
+  ) values (
+    v_clinic_id,
+    auth.uid(),
+    'pending',
+    p_notes,
+    null,
+    coalesce(v_patient_name, 'patient'),
+    p_appointment_id
+  )
+  returning id into v_entry_id;
+
+  -- stamp checkin_at on the appointment if not already set.
+  update public."Appointments"
+     set checkin_at = coalesce(checkin_at, (now() at time zone 'utc'))
+   where "Appointment_id" = p_appointment_id;
+
+  return v_entry_id;
+end;
+$$;
+
+revoke all on function public.join_queue_for_appointment(uuid, text) from public;
+grant execute on function public.join_queue_for_appointment(uuid, text)
+  to anon, authenticated, service_role;


### PR DESCRIPTION
## Summary

Provide a short description of what this PR does.
Makes the connection between the appointments and queue system.

If a patient walks in with no scheduled appointments, the visit is treated as a walk-in and at the end when their visit completes, a appointment row with appointment type "Walk-in" is created for this visit, 
nurses are able to see this in the calendar view, but the patient is not because the assigned clinician is a nurse, and there is rls restricitons on that right now. 

If a patient has a upcoming appointment, under the upcoming appointment box, they will see the option the check in queue for that appointment, this makes the appointment id for this appointment assigned with the queue_entry, so a new appointment does not need to be created as this is not a "walk-in" appointment", Only works for appointments whose status is "active"
---

## Changes Made

List the major changes included in this PR.

- Added RPC to join queue for scheduled visits
- altered RPC start visit to time stamp appointments
-altered  RPC complete visit to create a new appointment row for walk in type visits. 

---

## Type of Change

Please select the relevant option:

- [ ] Bug fix
- [] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Documentation update

---

## Testing

Describe how this change was tested.

- Ran frontend locally
- Verified expected behavior
- Tested edge cases if applicable

---

## Checklist

Before submitting this PR, please confirm:

- [x] Code compiles and runs locally
- [x] No unnecessary console logs
- [ ] Relevant issue is linked
- [x] Changes were tested
- [x] PR title clearly describes the change

---

## Additional Notes

Add any extra context, comments, or things reviewers should know.
