### PR TITLE
FIX: Appointment_status enum 'unseen' to 'requested', FIX: color matching throughout all appointment status UI

### DIFF
--- a/frontend/src/features/appointment/AppointmentCalendar.tsx
+++ b/frontend/src/features/appointment/AppointmentCalendar.tsx
@@ -87,7 +87,7 @@ export default function AppointmentCalendar({
     // if (viewPrefs.showReqs === 'all'){ 
     // const merged = [...eventsReq, ...events]; 
     //   return merged}
-    // else if (viewPrefs.showReqs === 'unseen'){ 
+    // else if (viewPrefs.showReqs === 'requested'){ 
     //   return eventsReq}
     // else if (viewPrefs.showReqs === 'active'){ 
     //   return events}

--- a/frontend/src/features/appointment/AppointmentList.tsx
+++ b/frontend/src/features/appointment/AppointmentList.tsx
@@ -411,7 +411,7 @@ export default function AppointmentList({
                         <span>{apt.patient_name}</span>
                         {/* ACTIONS TO EACH APPOINTMENT ROW */}
                         <span className="grid grid-cols-[33%_33%_33%]">
-                            {onSelectAppointment && (apt.appointment_status == 'unseen' ?
+                            {onSelectAppointment && (apt.appointment_status == 'requested' ?
                                 (<>
                                     <button 
                                     type="button"

--- a/frontend/src/features/appointment/AppointmentSwitch.tsx
+++ b/frontend/src/features/appointment/AppointmentSwitch.tsx
@@ -28,7 +28,7 @@ export default function AppointmentSwitch({
 
     const viewRequests : any[] = [
         'pending',  // patient needs to make changes 
-        'unseen',   // nurse/clinic has not seen it 
+        'requested',   // nurse/clinic has not seen it 
         'canceled', // appointment was canceled 
         'deserted',  // patient did not show up 
         'active',   // active = APPOINTMENTS 

--- a/frontend/src/features/appointment/ApptCreateModal.tsx
+++ b/frontend/src/features/appointment/ApptCreateModal.tsx
@@ -9,7 +9,7 @@ import type {
 import { Button } from '@/components/ui/button'; 
 import { statusColor } from './ApptUtil';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
-import ClinicSelector from '../queue/components/ClinicSelector';
+// import ClinicSelector from '../queue/components/ClinicSelector';
 
 type AppointmentCreateStatus = 'idle' | 'loading' | 'success' | 'failed'
 

--- a/frontend/src/features/appointment/ApptCreateModal.tsx
+++ b/frontend/src/features/appointment/ApptCreateModal.tsx
@@ -9,7 +9,7 @@ import type {
 import { Button } from '@/components/ui/button'; 
 import { statusColor } from './ApptUtil';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
-
+import ClinicSelector from '../queue/components/ClinicSelector';
 
 type AppointmentCreateStatus = 'idle' | 'loading' | 'success' | 'failed'
 
@@ -131,26 +131,32 @@ export default function ApptCreateModal({
 
 
                         {/* CLINIC SELECT */}
-                        { showClinicSelector ? (
-                        <div  className="flex justify-between">
-                        <label
-                            className='p-3 w-40 '
-                                >Clinic</label> 
-                        <select 
-                                className='p-2 w-full bg-[#F5F3EE] rounded-lg border border-solid text-end'
-                                value={selectedClinic}
-                                onChange={(e) =>{
-                            setSelectedClinic( e.target.value ) }
-                            }
-                        >
-                            {clinicList.map((d) => (
-                            <option key={d.clinic_id} value={d.clinic_id}>
-                                {d.clinic_name}
-                            </option>
-                            ))}
-                        </select>
-                        </div>
-                        ) : (<>
+                        { showClinicSelector ? ( <>
+                            <div  className="flex justify-between">
+                            <label
+                                className='p-3 w-40 '
+                                    >Clinic</label> 
+                            <select 
+                                    className='p-2 w-full bg-[#F5F3EE] rounded-lg border border-solid text-end'
+                                    value={selectedClinic}
+                                    onChange={(e) =>{
+                                setSelectedClinic( e.target.value ) }
+                                }
+                            >
+                                {clinicList.map((d) => (
+                                <option key={d.clinic_id} value={d.clinic_id}>
+                                    {d.clinic_name}
+                                </option>
+                                ))}
+                            </select>
+                            </div>
+                            {/* Proving difficult because of it's management specification to Queue */}
+                            {/* <ClinicSelector 
+                                clinics = {clinicList} 
+                                selectedClinicId = {selectedClinic}
+                                onSelect = {setSelectedClinic}
+                            />   */}
+                        </>) : (<>
                             <div  className="flex justify-between">
                                 <label className='p-3 w-40 '>
                                     Clinic</label> 

--- a/frontend/src/features/appointment/ApptUtil.ts
+++ b/frontend/src/features/appointment/ApptUtil.ts
@@ -7,7 +7,7 @@ export const statusColor = (status: string): string => {
   const STATUS_COLORS: Record<string, string> = {
     completed: "#16a34a", // green
     active: "#2563eb",    // blue
-    unseen: "#eab308",    // yellow
+    requested: "#eab308",    // yellow
     pending: "#f97316",   // orange
     canceled: "#dc2626",  // red
     deserted: "#7f1d1d",  // dark red

--- a/frontend/src/features/appointment/types.ts
+++ b/frontend/src/features/appointment/types.ts
@@ -97,7 +97,7 @@ export type UserClinicRelationship = {
 export type viewRequestTypes = 
     'all' | 
     'pending'|  // patient needs to make changes 
-    'unseen'|   // nurse/clinic has not seen it 
+    'requested'|   // nurse/clinic has not seen it 
     'canceled'| // appointment was canceled 
     'deserted'|  // patient did not show up 
     'active'|   // active = APPOINTMENTS 

--- a/frontend/src/pages/Dashboard/Nurse/NurseAppointmentManager.tsx
+++ b/frontend/src/pages/Dashboard/Nurse/NurseAppointmentManager.tsx
@@ -242,7 +242,7 @@ export default function NurseAppointmentManager() {
         searchValue: '',
         showReqs: [
             'pending',
-            'unseen',
+            'requested',
             'canceled',
             'deserted',
             'active',

--- a/frontend/src/pages/Dashboard/Patient/PatientAppointmentManager.tsx
+++ b/frontend/src/pages/Dashboard/Patient/PatientAppointmentManager.tsx
@@ -147,7 +147,7 @@ export default function PatientAppointmentManager() {
         date: '',
         time: '',
         type: '',
-        appointment_status: 'unseen',
+        appointment_status: 'requested',
         nurse_note: '',
         patient_note: '' 
     })
@@ -242,7 +242,7 @@ export default function PatientAppointmentManager() {
             date: `${yyyy}-${mm}-${dd}`,
             time: `${hh}:${min}`,  
             patientId: patientInfo.id,
-            appointment_status: 'unseen', 
+            appointment_status: 'requested', 
         }))
         // setShowAptUpdateForm(false)     // make sure updateForm is not open 
         setCreateStatus('idle')     // for UI 
@@ -267,7 +267,7 @@ export default function PatientAppointmentManager() {
         searchValue: '',
         showReqs: [ 
             'pending',
-            'unseen',
+            'requested',
             'canceled',
             'deserted',
             'active',

--- a/frontend/src/pages/Dashboard/Patient/PatientDashboard.tsx
+++ b/frontend/src/pages/Dashboard/Patient/PatientDashboard.tsx
@@ -12,7 +12,7 @@ import { useAuth } from '../../../context/AuthContext'
 
 type AppointmentStatus =
   | 'pending'
-  | 'unseen'
+  | 'requested'
   | 'canceled'
   | 'deserted'
   | 'active'
@@ -152,7 +152,7 @@ function getAppointmentBadgeClasses(status: AppointmentStatus) {
     case 'active':
       return 'bg-sky-100 text-sky-700'
     case 'pending':
-    case 'unseen':
+    case 'requested':
       return 'bg-indigo-100 text-indigo-700'
     case 'canceled':
     case 'deserted':
@@ -164,8 +164,8 @@ function getAppointmentBadgeClasses(status: AppointmentStatus) {
 
 function formatAppointmentStatus(status: AppointmentStatus) {
   switch (status) {
-    case 'unseen':
-      return 'requested - unseen'
+    case 'requested':
+      return 'requested'
     case 'active':
       return 'scheduled'
     case 'canceled':
@@ -314,7 +314,7 @@ export default function PatientDashboard() {
               }),
               doctor: row.clinician_name ?? 'Clinic Staff',
               type: row.visit_type ?? 'Appointment',
-              status: (row.appointment_status ?? 'unseen') as AppointmentStatus,
+              status: (row.appointment_status ?? 'requested') as AppointmentStatus,
               rawDate: row.appointment_date as string,
             }
           })
@@ -370,7 +370,7 @@ export default function PatientDashboard() {
   const upcomingAppointments = useMemo(
     () =>
       appointments.filter((a) =>
-        ['pending', 'unseen', 'active'].includes(a.status),
+        ['pending', 'requested', 'active'].includes(a.status),
       ),
     [appointments],
   )

--- a/supabase/migrations/20260428230636_Appointments_permissions_and_apptType_enum.sql
+++ b/supabase/migrations/20260428230636_Appointments_permissions_and_apptType_enum.sql
@@ -1,0 +1,17 @@
+-- alter TYPE if exists public."appointment_status" RENAME TO "apt_st_old";
+-- CREATE TYPE appointment_status AS ENUM ('active','requested','pending','canceled','deserted','completed'); 
+
+ALTER TYPE public."appointment_status"
+RENAME VALUE 'unseen' TO 'requested';
+
+
+ALTER TABLE if exists public."staff_permissions" 
+ADD COLUMN manage_appointment boolean;
+
+
+
+
+
+
+
+


### PR DESCRIPTION
## Summary
Minor Appointment UI changes, squashing a minor enum bug, and added a permissions column. 
---

## Changes Made
- FIX: Appointment_status enum 'unseen' to 'requested', 
- FIX: color matching throughout all appointment status UI 
- FEAT: add appointment management column to staff permissions table  

---

## Type of Change

Please select the relevant option:

- [X] Bug fix
- [X] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation update

---

## Testing

Describe how this change was tested.
- Ran frontend locally. Mostly minor UI so this should suffice.  
- `npx supabase db reset` to assure that db changes would work  
 

---

## Checklist

Before submitting this PR, please confirm:

- [X] Code compiles and runs locally
- [X] No unnecessary console logs
- [ ] Relevant issue is linked
- [X] Changes were tested
- [X] PR title clearly describes the change

---

## Additional Notes
Work to be done: 
- Still need to make sure appointment management actually checks for staff permissions. 
- Additionally I would like to take a look, and make sure all dashboards use the correct types and values. 
- double check how appointments will go back and forth between nurse and patient (if the pending status still has merit)  
**I figure these changes are short and I would like the production Supabase to Receives these changes first.** 
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 