### PR TITLE
Appointment Update to RLS && Patient appointment cancel button 

### DIFF
--- a/frontend/src/features/appointment/ApptUtil.ts
+++ b/frontend/src/features/appointment/ApptUtil.ts
@@ -13,7 +13,7 @@ export const statusColor = (status: string): string => {
     deserted: "#7f1d1d",  // dark red
     default: "#64748b",   // slate gray
   };
-  console.log(STATUS_COLORS[status])
+  // console.log(STATUS_COLORS[status])
   return STATUS_COLORS[status] ?? STATUS_COLORS.default;
 };
 

--- a/frontend/src/features/appointment/appointment.api.ts
+++ b/frontend/src/features/appointment/appointment.api.ts
@@ -54,26 +54,45 @@ export async function apiCreateAppt(
 }
 
 
-/////// UPDATE UTILITY 
-export async function apiUpdateAppt (input: UpdateApptForm):Promise<Appointment> {  
-    let appointmentDate = `${input.date} ${input.time}:00`
-    const { data, error } = await supabase
-        .schema('public')
-        .from('Appointments')
-        .update({
-            appointment_date: appointmentDate,
-            patient_id: input.patientId,
-            clinician_id: input.doctorId,
-            visit_type: input.type,
-            appointment_status: input.appointment_status, 
-            nurse_note: input.nurse_note 
-        })
-        .eq('Appointment_id', input.appointmentId)
-        .select('*')
-        .single() 
-    if (error) throw error
-    return data
+// /////// UPDATE UTILITY 
+// export async function apiUpdateAppt (input: UpdateApptForm):Promise<Appointment> {  
+//     let appointmentDate = `${input.date} ${input.time}:00`
+//     const { data, error } = await supabase
+//         .schema('public')
+//         .from('Appointments')
+//         .update({
+//             appointment_date: appointmentDate,
+//             patient_id: input.patientId,
+//             clinician_id: input.doctorId,
+//             visit_type: input.type,
+//             appointment_status: input.appointment_status, 
+//             nurse_note: input.nurse_note 
+//         })
+//         .eq('Appointment_id', input.appointmentId)
+//         .select('*')
+//         .single() 
+//     if (error) throw error
+//     return data
+// }
+export async function apiUpdateAppt(
+  input: UpdateApptForm
+): Promise<Appointment> {
+  const appointmentDate = `${input.date} ${input.time}:00`;
+
+  const { data, error } = await supabase.rpc("update_appt", {
+    p_appointment_id: input.appointmentId,
+    p_appointment_date: appointmentDate,
+    p_patient_id: input.patientId,
+    p_clinician_id: input.doctorId,
+    p_visit_type: input.type,
+    p_appointment_status: input.appointment_status,
+    p_nurse_note: input.nurse_note,
+  });
+
+  if (error) throw error;
+  return data;
 }
+
 export async function apiFetchSpecificAppt (input: Appointment):Promise<Appointment> {  
     const { data, error } = await supabase
       .schema('public')

--- a/frontend/src/pages/Dashboard/Patient/PatientAppointmentManager.tsx
+++ b/frontend/src/pages/Dashboard/Patient/PatientAppointmentManager.tsx
@@ -13,7 +13,7 @@ import ApptCreateModal from '@/features/appointment/ApptCreateModal.tsx';
 import { apiCreateAppt } from '@/features/appointment/appointment.api.ts';
 import { SidebarProvider } from '@/components/ui/sidebar'
 import ApptDetailModal from '@/features/appointment/ApptDetailModal.tsx';
- 
+import { apiUpdateAppt } from '@/features/appointment/appointment.api.ts';
 
 // CAN ONLY EDIT REQUESTS OR PENDING 
 
@@ -129,9 +129,9 @@ export default function PatientAppointmentManager() {
 
 
     // temparory empty f 
-    function emptyf(): void {
-        return
-    }
+    // function emptyf(): void {
+    //     return
+    // }
     
 
 
@@ -436,7 +436,35 @@ export default function PatientAppointmentManager() {
     //// U: UPDATE EXISTING APPOINTMENT
     // const updateAppointments = async () => { // relies on updateForm data 
     //     if(debuglog.includes('update')){console.log('UPDATEFORM SUBMITTED:', updateForm)}
- 
+    const cancelAppointment = async (apt: Appointment) => {
+    try {
+        const dt = new Date(apt.appointment_date);
+
+        const yyyy = dt.getFullYear();
+        const mm = String(dt.getMonth() + 1).padStart(2, "0");
+        const dd = String(dt.getDate()).padStart(2, "0");
+        const hh = String(dt.getHours()).padStart(2, "0");
+        const min = String(dt.getMinutes()).padStart(2, "0");
+
+        await apiUpdateAppt({
+            appointmentId: apt.Appointment_id,
+            patientId: apt.patient_id ?? "",
+            doctorId: apt.clinician_id ?? "",
+            date: `${yyyy}-${mm}-${dd}`,
+            time: `${hh}:${min}`,
+            type: apt.visit_type as AppointmentType,
+            appointment_status: "canceled",
+            nurse_note: apt.nurse_note ?? "",
+            patient_note: apt.patient_note ?? "",
+        });
+
+        if (clinicView) {
+            await readAppointments(clinicView, viewPrefs);
+        }
+    } catch (error) {
+        console.log("CANCEL APPOINTMENT ERROR:", error);
+    }
+    };
         
     //     ////// EXIT CASES  
     //     // UPDATE IT 
@@ -459,6 +487,7 @@ export default function PatientAppointmentManager() {
     //         // if(clinic) await readAppointments(clinic, viewPrefs)
     //     }
     // }
+
 
 
 
@@ -591,7 +620,7 @@ export default function PatientAppointmentManager() {
                                 appointments={appointmentsLoading ? [] : appointmentsList} // send a subset of appointments 
                                 // functions to handle appointment CRUD actions 
                                 onSelectAppointment={(apt) => openAppointmentDetails(apt)} 
-                                onDeleteAppointment={emptyf}
+                                onDeleteAppointment={(apt) => cancelAppointment(apt)}
                                 onSelectSlot={openCreateForm}
                                 // function to handle appointment view changes (changing query)
                                 viewPrefs={viewPrefs}

--- a/supabase/migrations/20260505023005_appointment update RPC.sql
+++ b/supabase/migrations/20260505023005_appointment update RPC.sql
@@ -1,0 +1,121 @@
+create function public.update_appt(
+  p_appointment_id uuid,
+  p_appointment_date timestamp,
+  p_patient_id uuid,
+  p_clinician_id uuid,
+  p_visit_type appointmenttypes,
+  p_appointment_status appointment_status,
+  p_nurse_note text
+)
+returns public."Appointments"
+language plpgsql
+security invoker
+as $$
+declare
+  updated_appt public."Appointments";
+  v_clinic_id uuid;
+  v_role text;
+begin
+  -- rate limit (optional but consistent)
+  perform public.check_rate_limit('update_appt', 20, 60);
+
+  -- get role
+  select role into v_role
+  from public.profiles
+  where id = auth.uid();
+
+  -- get clinic from appointment
+  select clinic_id into v_clinic_id
+  from public."Appointments"
+  where "Appointment_id" = p_appointment_id;
+
+  if v_clinic_id is null then
+    raise exception 'appointment not found';
+  end if;
+
+  -- permission logic
+  if v_role = 'patient' then
+  -- must own the appointment
+  if not exists (
+    select 1
+    from public."Appointments"
+    where "Appointment_id" = p_appointment_id
+      and patient_id = auth.uid()
+  ) then
+    raise exception 'patients can only update their own appointments';
+  end if;
+
+  -- patients can only cancel
+  if p_appointment_status <> 'canceled' then
+    raise exception 'patients may only cancel appointments';
+  end if;
+
+  -- prevent modifying anything else
+  if exists (
+    select 1
+    from public."Appointments"
+    where "Appointment_id" = p_appointment_id
+      and (
+        appointment_date is distinct from p_appointment_date
+        or clinician_id is distinct from p_clinician_id
+        or visit_type is distinct from p_visit_type
+        or nurse_note is distinct from p_nurse_note
+      )
+  ) then
+    raise exception 'patients may not modify appointment details';
+  end if;
+
+  elsif v_role = 'nurse' then
+    -- check staff_permissions
+    if not exists (
+      select 1
+      from public.staff_permissions sp
+      where sp.user_id = auth.uid()
+        and sp.clinic_id = v_clinic_id
+        and sp.manage_appointment = true
+    ) then
+      raise exception 'missing permission: manage_appointment';
+    end if;
+
+  else
+    raise exception 'role not allowed to update appointment';
+  end if;
+
+  -- perform update
+  update public."Appointments"
+  set
+    appointment_date = p_appointment_date,
+    patient_id = p_patient_id,
+    clinician_id = p_clinician_id,
+    visit_type = p_visit_type,
+    appointment_status = p_appointment_status,
+    nurse_note = p_nurse_note
+  where "Appointment_id" = p_appointment_id
+  returning * into updated_appt;
+
+  return updated_appt;
+end;
+$$;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/supabase/migrations/20260505032245_appointment RLS patient cancel our appointment.sql
+++ b/supabase/migrations/20260505032245_appointment RLS patient cancel our appointment.sql
@@ -1,0 +1,13 @@
+alter table public."Appointments" enable row level security;
+
+create policy "patients can cancel own appointments"
+on public."Appointments"
+for update
+to authenticated
+using (
+  patient_id = auth.uid()
+)
+with check (
+  patient_id = auth.uid()
+  and appointment_status = 'canceled'
+);


### PR DESCRIPTION

## Summary
fix minor appointment things. 
---

## Changes Made
- Convert Appointment Update to RPC using rate limit for patients and checking permissiosn for nurses. 
- Appointments table RLS so that patients cancel appointments 
- FIX: Patient appointment cancel button works 

---

## Type of Change

Please select the relevant option:

- [X] Bug fix
- [ ] New feature
- [X] Enhancement
- [ ] Refactor
- [ ] Documentation update

---

## Testing
- Ran frontend locally
- Verified expected behavior 

---

## Checklist

Before submitting this PR, please confirm:

- [X] Code compiles and runs locally
- [X] No unnecessary console logs
- [ ] Relevant issue is linked
- [X] Changes were tested
- [X] PR title clearly describes the change

---

## Additional Notes

Add any extra context, comments, or things reviewers should know.
