### PR TITLE
Implement Doctor Dashboard In-Progress Queue Integration

### DIFF
--- a/frontend/src/features/queue/api.ts
+++ b/frontend/src/features/queue/api.ts
@@ -93,6 +93,23 @@ export async function fetchOwnQueueRowsForClinic(clinicId: string): Promise<Queu
   return (data ?? []) as QueueEntryRow[]
 }
 
+export type DoctorQueuePatientRow = {
+  queue_entry_id: string
+  patient_id: string
+  patient_name: string | null
+  visit_type: string | null
+  status: string
+  started_at: string | null
+  appointment_id: string | null
+}
+
+export async function fetchDoctorInProgressQueue(): Promise<DoctorQueuePatientRow[]> {
+  const { data, error } = await supabase.rpc('get_doctor_in_progress_queue')
+
+  if (error) throw error
+  return (data ?? []) as DoctorQueuePatientRow[]
+}
+
 export async function fetchOwnActiveQueueRows(): Promise<QueueEntryRow[]> {
   const userId = await getCurrentUserId()
   const { data, error } = await supabase

--- a/frontend/src/pages/Dashboard/Doctor/DoctorDashBoard.tsx
+++ b/frontend/src/pages/Dashboard/Doctor/DoctorDashBoard.tsx
@@ -1,6 +1,8 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
+import { fetchDoctorInProgressQueue } from '@/features/queue/api'
+import type { DoctorQueuePatientRow } from '@/features/queue/api'
 
 type DoctorStage = 'waiting' | 'consultation' | 'completed'
 
@@ -67,91 +69,34 @@ const INITIAL_CLINICAL_NOTE: ClinicalNote = {
   followUpNotes: '',
 }
 
+
+function formatArrivalTime(startedAt: string | null) {
+  if (!startedAt) return 'Unknown'
+
+  return new Date(startedAt).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function mapQueueRowToDoctorPatient(row: DoctorQueuePatientRow): DoctorPatient {
+  return {
+    id: row.queue_entry_id,
+    patientName: row.patient_name ?? 'Unknown patient',
+    age: 0,
+    gender: 'Unknown',
+    appointmentType: row.visit_type ?? 'Visit',
+    symptoms: 'No visit reason provided.',
+    stage: 'consultation',
+    arrivalTime: formatArrivalTime(row.started_at),
+    formsComplete: true,
+  }
+}
+
 export default function DoctorDashBoard() {
-  const [patients, setPatients] = useState<DoctorPatient[]>([
-    {
-      id: '1',
-      patientName: 'Jane Doe',
-      age: 34,
-      gender: 'Female',
-      appointmentType: 'General Check-up',
-      symptoms: 'Persistent headache, fatigue for 3 days',
-      stage: 'consultation',
-      arrivalTime: '09:15 AM',
-      formsComplete: true,
-      intakeForm: {
-        allergies: 'Penicillin',
-        medications: 'Lisinopril 10mg daily',
-        medicalHistory: 'Hypertension (diagnosed 2020)',
-        emergencyContact: 'John Doe (spouse) - 555-0123',
-      },
-      medicalHistory: [
-        {
-          date: '2024-11-15',
-          diagnosis: 'Upper respiratory infection',
-          notes: 'Prescribed amoxicillin 500mg. Symptoms resolved after 7 days.',
-          doctor: 'Dr. Smith',
-        },
-        {
-          date: '2024-08-22',
-          diagnosis: 'Annual physical examination',
-          notes: 'All vitals normal. Continue current hypertension medication.',
-          doctor: 'Dr. Johnson',
-        },
-      ],
-      testResults: [
-        {
-          id: 't1',
-          type: 'Blood Panel',
-          date: '2024-08-22',
-          result: 'Normal',
-          notes: 'All values within normal range',
-        },
-      ],
-    },
-    {
-      id: '2',
-      patientName: 'John Smith',
-      age: 58,
-      gender: 'Male',
-      appointmentType: 'Follow-up',
-      symptoms: 'Chest discomfort, shortness of breath',
-      stage: 'waiting',
-      arrivalTime: '09:30 AM',
-      formsComplete: false,
-      intakeForm: {
-        allergies: 'None',
-        medications: 'Metformin 500mg twice daily, Atorvastatin 20mg',
-        medicalHistory: 'Type 2 Diabetes, High cholesterol',
-        emergencyContact: 'Sarah Smith (daughter) - 555-0456',
-      },
-      medicalHistory: [
-        {
-          date: '2024-12-01',
-          diagnosis: 'Type 2 Diabetes follow-up',
-          notes: 'HbA1c at 7.2%. Continue current regimen. Recommend dietary counseling.',
-          doctor: 'Dr. Martinez',
-        },
-      ],
-    },
-    {
-      id: '3',
-      patientName: 'Maria Garcia',
-      age: 42,
-      gender: 'Female',
-      appointmentType: 'Consultation',
-      symptoms: 'Lower back pain for 2 weeks',
-      stage: 'waiting',
-      arrivalTime: '09:45 AM',
-      formsComplete: true,
-      intakeForm: {
-        allergies: 'Latex',
-        medications: 'Ibuprofen as needed',
-        medicalHistory: 'No significant medical history',
-        emergencyContact: 'Carlos Garcia (husband) - 555-0789',
-      },
-    },
-  ])
+  const [patients, setPatients] = useState<DoctorPatient[]>([])
+  const [isLoadingQueue, setIsLoadingQueue] = useState(true)
+  const [queueError, setQueueError] = useState<string | null>(null)
 
   const [selectedPatientId, setSelectedPatientId] = useState<string | null>(null)
   const [clinicalNote, setClinicalNote] = useState<ClinicalNote>(INITIAL_CLINICAL_NOTE)
@@ -160,6 +105,45 @@ export default function DoctorDashBoard() {
   const [newTestResult, setNewTestResult] = useState({ type: '', result: '', notes: '' })
   const [saveNoteFeedback, setSaveNoteFeedback] = useState<string | null>(null)
   const [flagFormsFeedback, setFlagFormsFeedback] = useState<string | null>(null)
+
+  useEffect(() => {
+    let isMounted = true
+
+    async function loadDoctorQueue() {
+      try {
+        setIsLoadingQueue(true)
+        setQueueError(null)
+
+        const rows = await fetchDoctorInProgressQueue()
+        const mappedPatients = rows.map(mapQueueRowToDoctorPatient)
+
+        if (!isMounted) return
+
+        setPatients(mappedPatients)
+        setSelectedPatientId((currentId) => {
+          if (!currentId) return currentId
+          return mappedPatients.some((patient) => patient.id === currentId)
+            ? currentId
+            : null
+        })
+      } catch (error) {
+        console.error('Failed to load doctor queue:', error)
+
+        if (!isMounted) return
+        setQueueError('Unable to load doctor queue.')
+      } finally {
+        if (isMounted) {
+          setIsLoadingQueue(false)
+        }
+      }
+    }
+
+    void loadDoctorQueue()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
 
   const selectedPatient = patients.find((p) => p.id === selectedPatientId)
 
@@ -243,8 +227,12 @@ export default function DoctorDashBoard() {
             <h2 className="text-lg font-semibold text-gray-900">Patient Queue</h2>
           </div>
           <div className="p-4">
-            {patients.length === 0 ? (
-              <p className="text-sm text-gray-500">No patients assigned.</p>
+            {isLoadingQueue ? (
+              <p className="text-sm text-gray-500">Loading doctor queue...</p>
+            ) : queueError ? (
+              <p className="text-sm text-red-600">{queueError}</p>
+            ) : patients.length === 0 ? (
+              <p className="text-sm text-gray-500">No patients currently in progress.</p>
             ) : (
               <div className="space-y-2">
                 {patients.map((patient, index) => (

--- a/supabase/migrations/20260505182235_get_doctor_in_progress_queue.sql
+++ b/supabase/migrations/20260505182235_get_doctor_in_progress_queue.sql
@@ -1,0 +1,33 @@
+create or replace function public.get_doctor_in_progress_queue()
+returns table (
+  queue_entry_id uuid,
+  patient_id uuid,
+  patient_name text,
+  visit_type text,
+  status text,
+  started_at timestamptz,
+  appointment_id uuid
+)
+language sql
+security definer
+set search_path = public
+as $$
+  select
+    q.id as queue_entry_id,
+    q.patient_id,
+    q.patient_name,
+    a.visit_type::text,
+    q.status::text,
+    q.started_at,
+    q.appointment_id
+  from public.queue_entries q
+  join public."Appointments" a
+    on a."Appointment_id" = q.appointment_id
+  where q.status = 'in_progress'
+    and q.is_active = true
+    and a.clinician_id = auth.uid()
+  order by q.started_at asc;
+$$;
+
+revoke all on function public.get_doctor_in_progress_queue() from public;
+grant execute on function public.get_doctor_in_progress_queue() to authenticated;


### PR DESCRIPTION
## Related Issue

Fixes #59

---

## Summary

Implements the Doctor Dashboard queue integration for patients whose queue status is `in_progress`.

- Replaces mock doctor queue data with real Supabase queue data
- Displays patients currently ready for doctor consultation
- Removes patients from the doctor queue once their visit is completed

---

## Changes Made

- Added Supabase RPC for fetching the doctor’s active `in_progress` queue
- Added frontend API helper for loading doctor queue rows
- Updated `DoctorDashBoard.tsx` to fetch real queue patients instead of mock data
- Mapped queue rows into the existing doctor queue tile UI
- Added loading, error, and empty states for the doctor queue
- Confirmed completed visits disappear from the Doctor Dashboard queue

---

## Type of Change

Please select the relevant option:

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation update

---

## Testing

- Ran frontend locally
- Verified nurse queue lifecycle:
  - patient joins queue
  - nurse accepts patient
  - nurse calls patient
  - nurse assigns doctor
  - nurse starts visit
  - patient appears on Doctor Dashboard
  - nurse completes visit
  - patient disappears from Doctor Dashboard
- Verified Doctor Dashboard empty state when no patients are in progress

---

## Checklist

Before submitting this PR, please confirm:

- [x] Code compiles and runs locally
- [x] No unnecessary console logs
- [x] Relevant issue is linked
- [x] Changes were tested
- [x] PR title clearly describes the change

---

## Additional Notes

This PR focuses only on displaying patients in the Doctor Dashboard queue when their queue status becomes `in_progress`. Full patient chart/file viewing is intentionally left for a separate future issue.